### PR TITLE
Changes updateBall signature to Model as param

### DIFF
--- a/4. Game loop.md
+++ b/4. Game loop.md
@@ -34,6 +34,21 @@ updateBall delta model =
 
 In Elm you can create local variables inside functions using the `let .. in` syntax like above. Here we set ball to the inner record of model for convenience and to be able to return a updated value of the ball.
 
+We can skip the extra step of storing `ball` as a variable by using pattern matching to destructure the passed in model and get `ball` directly in the parameter position:
+
+```Elm
+updateBall : Float -> Model -> Ball
+updateBall delta {ball} =
+	-- Check if the ball is outside the board on either end
+	if ball.x < -ball.radius || ball.x > boardWidth + ball.radius then
+		{ ball
+            | x = boardWidth / 2
+            , y = boardHeight / 2
+        }
+	else
+		model
+```
+
 If the ball is not outside the bounds, we need to check if it collides with any of the paddles or the top or bottom wall.
 
 We can move the paddle detection into some helper functions. The `within` function takes a `Ball` and `Paddle` and checks if the ball is within the paddle frame. You can just copy these into your file:
@@ -50,11 +65,11 @@ within ball paddle =
         && near (paddle.y + paddle.height / 2) (paddle.height / 2 + ball.radius) ball.y
 ```
 
-We can now use these functions to update the direction of our ball. Let's start by calculating the updated velocity `vx`:
+We can now use these functions to update the direction of our ball. Let's start by calculating the updated velocity `vx`. We also extend the pattern matching of the model to retrieve `paddleLeft` and `paddleRight`:
 
 ```Elm
 updateBall : Float -> Model -> Ball
-updateBall delta model =
+updateBall delta {ball, paddleLeft, paddleRight} =
     ...
     else
         let
@@ -75,7 +90,7 @@ We also need to update our `vy` property:
 
 ```Elm
 updateBall : Float -> Model -> Ball
-updateBall delta model =
+updateBall delta {ball, paddleLeft, paddleRight} =
     ...
     else
         let
@@ -107,7 +122,7 @@ The last thing we need for our `updateBall` function is to calculate the new `x`
 
 ```Elm
 updateBall : Float -> Model -> Ball
-updateBall delta model =
+updateBall delta {ball, paddleLeft, paddleRight} =
     ...
     else
         let
@@ -289,8 +304,7 @@ updatePaddle delta paddle =
 
 
 updateBall : Float -> Model -> Ball
-updateBall delta model =
-    let ball = model.ball in
+updateBall delta {ball, paddleLeft, paddleRight} =
     if ball.x < -ball.radius || ball.x > boardWidth + ball.radius then
         { ball
             | x = boardWidth / 2
@@ -299,9 +313,9 @@ updateBall delta model =
     else
         let
             vx =
-                if within ball model.paddleLeft then
+                if within ball paddleLeft then
                     abs ball.vx
-                else if within ball model.paddleRight then
+                else if within ball paddleRight then
                     -(abs ball.vx)
                 else
                     ball.vx
@@ -320,7 +334,6 @@ updateBall delta model =
                 , vx = vx
                 , vy = vy
             }
-
 
 near : Float -> Float -> Float -> Bool
 near a spacing b =

--- a/4. Game loop.md
+++ b/4. Game loop.md
@@ -34,7 +34,7 @@ updateBall delta model =
 
 In Elm you can create local variables inside functions using the `let .. in` syntax like above. Here we set ball to the inner record of model for convenience and to be able to return a updated value of the ball.
 
-We can skip the extra step of storing `ball` as a variable by using pattern matching to destructure the passed in model and get `ball` directly in the parameter position:
+We can skip the extra step of storing `ball` as a variable by using [pattern matching to destructure](https://gist.github.com/yang-wei/4f563fbf81ff843e8b1e) the passed in model and get `ball` directly in the parameter position:
 
 ```Elm
 updateBall : Float -> Model -> Ball

--- a/4. Game loop.md
+++ b/4. Game loop.md
@@ -7,19 +7,21 @@ Now that we have all our subscriptions set up, it's time to start making things 
 When the ball moves outside the board on either end, we just reset the ball in the middle. If not, we calculate the new velocity by checking wether the ball collides with a paddle or the bounds of
 the board. We also want to update the position by multiplying the velocity with the time delta.
 
-To avoid getting a huge `update` function we can create a separate functions for updating the ball. Let's call it `updateBall` and pass in the two paddles, the time delta and the previous ball:
+To avoid getting a huge `update` function we can create a separate functions for updating the ball. Let's call it `updateBall` and pass in the the time delta and the model which holds the two paddles and the previous ball. Here we pass in the model as a parameter to avoid being dependent of order of left and right paddle:
 
 ```Elm
-updateBall : Float -> Paddle -> Paddle -> Ball -> Ball
-updateBall delta paddleLeft paddleRight ball =
+updateBall : Float -> Model -> Ball
+updateBall delta model =
 	...
 ```
 
 The first thing we can check for is wether or not the ball is outside the bounds of the board. We're not doing any score tracking in this game, so we can just reset the position of the ball to the center of the board when that happens:
 
 ```Elm
-updateBall : Float -> Paddle -> Paddle -> Ball -> Ball
-updateBall delta paddleLeft paddleRight ball =
+updateBall : Float -> Model -> Ball
+updateBall delta model =
+	-- Get the ball from the model for convenience
+	let ball = model.ball in
 	-- Check if the ball is outside the board on either end
 	if ball.x < -ball.radius || ball.x > boardWidth + ball.radius then
 		{ ball
@@ -29,6 +31,8 @@ updateBall delta paddleLeft paddleRight ball =
 	else
 		model
 ```
+
+In Elm you can create local variables inside functions using the `let .. in` syntax like above. Here we set ball to the inner record of model for convenience and to be able to return a updated value of the ball.
 
 If the ball is not outside the bounds, we need to check if it collides with any of the paddles or the top or bottom wall.
 
@@ -49,15 +53,15 @@ within ball paddle =
 We can now use these functions to update the direction of our ball. Let's start by calculating the updated velocity `vx`:
 
 ```Elm
-updateBall : Float -> Paddle -> Paddle -> Ball -> Ball
-updateBall delta paddleLeft paddleRight ball =
+updateBall : Float -> Model -> Ball
+updateBall delta model =
     ...
     else
         let
             vx =
-                if within ball paddleLeft then
+                if within ball model.paddleLeft then
                     abs ball.vx
-                else if within ball paddleRight then
+                else if within ball model.paddleRight then
                     -(abs ball.vx)
                 else
                     ball.vx
@@ -65,22 +69,20 @@ updateBall delta paddleLeft paddleRight ball =
 	        { ball | vx = vx }
 ```
 
-In Elm you can create local variables inside functions using the `let .. in` syntax like above.
-
 If the ball is within the left paddle we take the absolute value of the previous velocity. This will make the paddle move to the right. If the paddle is within the right paddle, we make the ball go the opposite direction. If not we just keep the current velocity.
 
 We also need to update our `vy` property:
 
 ```Elm
-updateBall : Float -> Paddle -> Paddle -> Ball -> Ball
-updateBall delta paddleLeft paddleRight ball =
+updateBall : Float -> Model -> Ball
+updateBall delta model =
     ...
     else
         let
             vx =
-                if within ball paddleLeft then
+                if within ball model.paddleLeft then
                     abs ball.vx
-                else if within ball paddleRight then
+                else if within ball model.paddleRight then
                     -(abs ball.vx)
                 else
                     ball.vx
@@ -104,8 +106,8 @@ Here we flip the direction of the velocity if the ball hits the top or bottom wa
 The last thing we need for our `updateBall` function is to calculate the new `x` and `y` position. To do this we simply need to multiply the time delta with our velocity and add that to the previous `x` and `y` values:
 
 ```Elm
-updateBall : Float -> Paddle -> Paddle -> Ball -> Ball
-updateBall delta paddleLeft paddleRight ball =
+updateBall : Float -> Model -> Ball
+updateBall delta model =
     ...
     else
         let
@@ -146,7 +148,7 @@ updatePaddle direction delta paddle =
     { paddle | y = paddle.y + paddle.vy * delta }
 ```
 
-This would work, but the paddle can still move outside the bounds of our board. Let's constrain their movement by using the `clamp` function: 
+This would work, but the paddle can still move outside the bounds of our board. Let's constrain their movement by using the `clamp` function:
 
 ```Elm
 updatePaddle : Float -> Paddle -> Paddle
@@ -268,7 +270,7 @@ update msg model =
     case msg of
         Tick delta ->
             ( { model
-                | ball = updateBall delta model.paddleLeft model.paddleRight model.ball
+                | ball = updateBall delta model
                 , paddleLeft = updatePaddle delta model.paddleLeft
                 , paddleRight = updatePaddle delta model.paddleRight
               }
@@ -286,8 +288,9 @@ updatePaddle delta paddle =
     }
 
 
-updateBall : Float -> Paddle -> Paddle -> Ball -> Ball
-updateBall delta paddleLeft paddleRight ball =
+updateBall : Float -> Model -> Ball
+updateBall delta model =
+    let ball = model.ball in
     if ball.x < -ball.radius || ball.x > boardWidth + ball.radius then
         { ball
             | x = boardWidth / 2
@@ -296,9 +299,9 @@ updateBall delta paddleLeft paddleRight ball =
     else
         let
             vx =
-                if within ball paddleLeft then
+                if within ball model.paddleLeft then
                     abs ball.vx
-                else if within ball paddleRight then
+                else if within ball model.paddleRight then
                     -(abs ball.vx)
                 else
                     ball.vx
@@ -395,5 +398,4 @@ main =
         , view = view
         , subscriptions = subscriptions
         }
-
 ```

--- a/5. Keyboard events.md
+++ b/5. Keyboard events.md
@@ -143,7 +143,7 @@ update msg model =
 		...
         Tick delta ->
             ( { model
-                | ball = updateBall delta model.paddleLeft model.paddleRight model.ball
+                | ball = updateBall delta model
                 , paddleLeft = updatePaddle (paddleDirectionLeft model.keysDown) delta model.paddleLeft
                 , paddleRight = updatePaddle (paddleDirectionRight model.keysDown) delta model.paddleRight
               }
@@ -258,7 +258,7 @@ update msg model =
 
         Tick delta ->
             ( { model
-                | ball = updateBall delta model.paddleLeft model.paddleRight model.ball
+                | ball = updateBall delta model
                 , paddleLeft = updatePaddle (paddleDirectionLeft model.keysDown) delta model.paddleLeft
                 , paddleRight = updatePaddle (paddleDirectionRight model.keysDown) delta model.paddleRight
               }
@@ -276,8 +276,9 @@ updatePaddle direction delta paddle =
     }
 
 
-updateBall : Float -> Paddle -> Paddle -> Ball -> Ball
-updateBall delta paddleLeft paddleRight ball =
+updateBall : Float -> Model -> Ball
+updateBall delta model =
+    let ball = model.ball in
     if ball.x < -ball.radius || ball.x > boardWidth + ball.radius then
         { ball
             | x = boardWidth / 2
@@ -286,9 +287,9 @@ updateBall delta paddleLeft paddleRight ball =
     else
         let
             vx =
-                if within ball paddleLeft then
+                if within ball model.paddleLeft then
                     abs ball.vx
-                else if within ball paddleRight then
+                else if within ball model.paddleRight then
                     -(abs ball.vx)
                 else
                     ball.vx

--- a/5. Keyboard events.md
+++ b/5. Keyboard events.md
@@ -277,8 +277,7 @@ updatePaddle direction delta paddle =
 
 
 updateBall : Float -> Model -> Ball
-updateBall delta model =
-    let ball = model.ball in
+updateBall delta {ball, paddleLeft, paddleRight} =
     if ball.x < -ball.radius || ball.x > boardWidth + ball.radius then
         { ball
             | x = boardWidth / 2
@@ -287,9 +286,9 @@ updateBall delta model =
     else
         let
             vx =
-                if within ball model.paddleLeft then
+                if within ball paddleLeft then
                     abs ball.vx
-                else if within ball model.paddleRight then
+                else if within ball paddleRight then
                     -(abs ball.vx)
                 else
                     ball.vx


### PR DESCRIPTION
This PR is more for starting a discussion. It changes updateBall to use Model as input instead of separate inputs. 

```diff
-updateBall : Float -> Paddle -> Paddle -> Ball -> Ball
+updateBall : Float -> Model -> Ball
```

The motivation is to not be dependent on order of parameters which I think might be an API flaw. It more easily allows for logical errors where you can mix up left and right paddles (even though you have tools like auto complete and documentation that show the naming of the paramteres). It might also be a difficult error to debug after the fact.

I've also extended the example to use pattern matching to destruct the model on input, to have the same function body and show how pattern matching can be used on structural typed records.

```elm
updateBall delta {ball, paddleLeft, paddleRight} =
```

Let me know what you think, @rechsteiner 